### PR TITLE
Do not hide mysql connection errors with success response

### DIFF
--- a/app/controllers/leaderboard/boards_controller.rb
+++ b/app/controllers/leaderboard/boards_controller.rb
@@ -1,12 +1,7 @@
 module Leaderboard
   class BoardsController < ApplicationController
     skip_before_action :redirect_to_login_if_required, :check_xhr
-
     respond_to :html, :json
-
-    rescue_from Mysql2::Error do
-      render json: {}, status: 200
-    end
 
     def index
       respond_to do |format|


### PR DESCRIPTION
@CalebFenton 

> hello, we noticed a problem with https://openx.srcclr.io/bughunt

it seems like we had silence error report on any mysql connection error, and as a server is a black box, probably it would be better to say "Somethig went wrong" instead silence "No challenges found" ?

**Changelog**
- Show error message if mysql connection occur.

![img](http://i.imgur.com/4FsF5Qz.png)
